### PR TITLE
Fix csproj BOM and PackagePath

### DIFF
--- a/RtFlow.Pipelines.Core/RtFlow.Pipelines.Core.csproj
+++ b/RtFlow.Pipelines.Core/RtFlow.Pipelines.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -39,7 +39,7 @@
 
   <!-- Package Content -->
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- remove BOM from the RtFlow.Pipelines.Core project file
- correct the README `<None Include>` entry

## Testing
- `dotnet build RtFlow.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448fdd146c8324918ceda67aead779